### PR TITLE
optimize "lgw rx" loop

### DIFF
--- a/modules/sx1302_2_1_0/lgw_cmd.c
+++ b/modules/sx1302_2_1_0/lgw_cmd.c
@@ -43,6 +43,10 @@
 
 #include "loragw_sx1302.h"
 
+
+#define FETCH_SLEEP_MS      10          /* nb of ms waited when a fetch return no packets */
+
+
 #ifdef ENDPOINT_DEVADDR
 
 static const lgw_sx130x_endpoint_t lgw_sx130x_default_endpoint = {
@@ -1310,6 +1314,7 @@ static int lgw_rx_cmd(int argc, char **argv) {
 			printf("Received %d packets (total:%lu)\n", nb_pkt, nb_pkt_crc_ok);
 		} else {
 			// printf("No packet");
+			xtimer_msleep(FETCH_SLEEP_MS);
 		}
 
 #if INVOKE_CALLBACKS == 1

--- a/modules/sx1302_2_1_0/riot_loragw_spi.c
+++ b/modules/sx1302_2_1_0/riot_loragw_spi.c
@@ -47,7 +47,7 @@ License: Revised BSD License, see LICENSE.TXT file include in the project
 #define WRITE_ACCESS 0x80
 
 #ifndef SPI_PAUSE_DELAY
-#define SPI_PAUSE_DELAY 1000
+#define SPI_PAUSE_DELAY 100
 #endif
 
 #if SPI_PAUSE_DELAY == 0

--- a/modules/sx1302_2_1_0/riot_sx1250_spi.c
+++ b/modules/sx1302_2_1_0/riot_sx1250_spi.c
@@ -42,7 +42,7 @@ License: Revised BSD License, see LICENSE.TXT file include in the project
 
 
 #ifdef RIOT_APPLICATION
-#define SPI_PAUSE_DELAY  1000
+#define SPI_PAUSE_DELAY  100
 
 #if SPI_PAUSE_DELAY == 0
 #define SPI_PAUSE

--- a/modules/sx1302_2_1_0/riot_sx1261_spi.c
+++ b/modules/sx1302_2_1_0/riot_sx1261_spi.c
@@ -41,7 +41,7 @@ License: Revised BSD License, see LICENSE.TXT file include in the project
 #include "sx1261_spi.h"
 
 #ifdef RIOT_APPLICATION
-#define SPI_PAUSE_DELAY  1000
+#define SPI_PAUSE_DELAY  100
 
 #if SPI_PAUSE_DELAY == 0
 #define SPI_PAUSE

--- a/tests/driver_sx1302/Makefile
+++ b/tests/driver_sx1302/Makefile
@@ -194,6 +194,7 @@ USEMODULE += printf_float
 
 USEMODULE += git
 USEMODULE += i2c_scan_utils
+USEMODULE += schedstatistics
 
 # -----------------------------
 # SX1302 Lib 


### PR DESCRIPTION
Reduce the pause after each SPI transaction
and add a pause if no packet can be fetched (like the packet forwarder behavior)

With this change, the loop will be more efficient when receiving packets, and System load when the gateway is idle is the same.
Here is a ps, 30s after the "lgw listen"

```
before
> ps
        pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     | runtime  | switches  | runtime_usec
          2 | LGW_LISTEN           | bl mutex _ |   6 |  16384 ( 2040) (14344) | 0x20007f7c | 0x2000b7b4  |  2.358% |     34206  |    1273946
after
> ps
        pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     | runtime  | switches  | runtime_usec
          2 | LGW_LISTEN           | bl mutex _ |   6 |  16384 ( 2040) (14344) | 0x20007f7c | 0x2000b8bc  |  2.421% |     34698  |    1247984
```