### PR TITLE
i2c_scan: remplace fputs by printf

### DIFF
--- a/modules/i2c_scan_utils/i2c_scan.c
+++ b/modules/i2c_scan_utils/i2c_scan.c
@@ -62,7 +62,7 @@ int mission_i2c_scan(const int idx) {
 
 	for (char i = 0; i < 8; i++) {
 		char row[] = { '0', 'x', '0' + i, '0', '\0' };
-		fputs(row, stdout);
+		printf("%s",row);
 		uint16_t addr = i;
 		addr <<= 4;
 		for (unsigned j = 0; j < 16; j++) {
@@ -91,7 +91,7 @@ int mission_i2c_scan(const int idx) {
 				}
 			}
 
-			fputs(str, stdout);
+			printf("%s",str);
 			addr++;
 		}
 		puts("");


### PR DESCRIPTION
This patch avoid fputs issue due to data buffering

Before

```
INFO: Scanning I2C device 0...
addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
     0 1 2 3 4 5 6 7 8 9 a b c d e f








INFO: Scanning adresses from 0x00 to 0x7F ...
INFO:  - i2c device found at address: 0x18 [Temperature sensor (MCP9808)]

INFO: 1 (/1) devices found on I2C_DEV(0)
Packet Forwarder for RIOT Gateway (Version: undefined)
INFO: Little endian host
Gateway ID: 0x6a33773014513831
> 0x00 R R R R R R R R - - - - - - - -0x10 - - - - - - - - X - - - - - - -0x20 - - - - - - - - - - - - - - - -0x30 - - - - - - - - - - - - - - - -0x40 - - - - - - - - - - - - - - - -0x50 - - - - - - - - - - - - - - - -0x60 - - - - - - - - - - - - - - - -0x70 - - - - - - - - R R R R R R R R
>
```

After

```
INFO: Scanning I2C device 0...
addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
     0 1 2 3 4 5 6 7 8 9 a b c d e f
0x00 R R R R R R R R - - - - - - - -
0x10 - - - - - - - - X - - - - - - -
0x20 - - - - - - - - - - - - - - - -
0x30 - - - - - - - - - - - - - - - -
0x40 - - - - - - - - - - - - - - - -
0x50 - - - - - - - - - - - - - - - -
0x60 - - - - - - - - - - - - - - - -
0x70 - - - - - - - - R R R R R R R R
INFO: Scanning adresses from 0x00 to 0x7F ...
INFO:  - i2c device found at address: 0x18 [Temperature sensor (MCP9808)]

INFO: 1 (/1) devices found on I2C_DEV(0)
```